### PR TITLE
Remove callback from included concern and bump version to 0.5.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    clever_events_rails (0.4.0)
+    clever_events_rails (0.5.0)
       activesupport
       aws-sdk-sns
       railties (>= 4.1)

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 Add the gem to your gemfile:
 ```ruby
-gem "clever_events_rails", "~> 0.4.0", git: "https://github.com/clever-real-estate/clever-events-rails"
+gem "clever_events_rails", "~> 0.5.0", git: "https://github.com/clever-real-estate/clever-events-rails"
 ```
 
 ```

--- a/README.md
+++ b/README.md
@@ -31,13 +31,15 @@ You can include the gem's module in the model you want to publish events from:
 class Object < ApplicationRecord
   include CleverEvents::Publishable
   ...
+  after_save :publish_event!
 end
 ```
 
 Simply including the `Publishable` module it will give access to a few methods:
 - `publishable_attrs` is a class attribute, that accepts an array of symbols corresponding to the attributes we want to send events about (updates only).
 - `publishable_actions` is another class attribute that accepts an array of symbols, corresponding to the _actions_ that the object undergoes. If this is not explicitly added, the defaults are `[:create, :update, :destroy]`.
-- `#publish_event` is automatically included. It synchrounously publishes an event via the adapter specified.
+- `#publish_event!` is automatically included. It synchronously publishes an event via the adapter specified.
+- `#publish_event?` is included and checks to see if the attrs were updated in the action given
 
 If you want to implement your own `#publish_event` method, just implement it in the model:
 ```ruby

--- a/gemfiles/rails_7_1.gemfile.lock
+++ b/gemfiles/rails_7_1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    clever_events_rails (0.4.0)
+    clever_events_rails (0.5.0)
       activesupport
       aws-sdk-sns
       railties (>= 4.1)

--- a/gemfiles/rails_8_0.gemfile.lock
+++ b/gemfiles/rails_8_0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    clever_events_rails (0.4.0)
+    clever_events_rails (0.5.0)
       activesupport
       aws-sdk-sns
       railties (>= 4.1)

--- a/lib/clever_events_rails/clever_events/publishable.rb
+++ b/lib/clever_events_rails/clever_events/publishable.rb
@@ -11,10 +11,6 @@ module CleverEvents
       class_attribute :_publishable_attrs, default: []
       class_attribute :_publishable_actions, default: %i[created updated destroyed]
 
-      after_commit do
-        publish_event! if publish_event?
-      end
-
       def publish_event!
         CleverEvents::Publisher.publish_event!(event_name, self, message_deduplication_id)
       rescue StandardError => e

--- a/lib/clever_events_rails/version.rb
+++ b/lib/clever_events_rails/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module CleverEventsRails
-  VERSION = "0.4.0"
+  VERSION = "0.5.0"
 end

--- a/spec/clever_events/publishable_spec.rb
+++ b/spec/clever_events/publishable_spec.rb
@@ -51,20 +51,24 @@ RSpec.describe CleverEvents::Publishable do
     let(:test_object) { build_stubbed(:test_object) }
 
     before do
-      allow(test_object).to receive(:_publishable_actions).and_return(%i[created updated destroyed])
+      allow(test_object.class).to receive(:_publishable_actions).and_return(%i[created updated destroyed])
     end
 
     it "defines the actions to be published" do
-      expect(test_object.class._publishable_actions).to eq(%i[updated])
+      expect(test_object.class._publishable_actions).to eq(%i[created updated destroyed])
     end
 
     describe "when a publishable action is performed" do
       let(:test_object) { create(:test_object) }
 
+      before do
+        allow(test_object.class).to receive(:_publishable_actions).and_return(%i[destroyed])
+      end
+
       it "calls the publish_event! method" do
-        test_object.update(first_name: "New Name")
+        test_object.destroy
         expect(CleverEvents::Publisher).to have_received(:publish_event!)
-          .with("TestObject.updated", test_object, test_uuid)
+          .with("TestObject.destroyed", test_object, test_uuid)
       end
 
       describe "when publish_event! raises an error" do

--- a/spec/dummy_app/app/models/test_object.rb
+++ b/spec/dummy_app/app/models/test_object.rb
@@ -7,4 +7,7 @@ class TestObject < ActiveRecord::Base
 
   publishable_attrs :first_name, :last_name, :email, :phone
   publishable_actions :updated
+
+  after_save :publish_event!, if: :publish_event?
+  after_destroy :publish_event!, if: :publish_event?
 end


### PR DESCRIPTION
Allow clients to configure their own callback for event publishing. Update the gem version to reflect these changes.