### PR TITLE
QoL - Allow publish skipping via ivar on publishable object

### DIFF
--- a/lib/clever_events_rails/clever_events/publishable.rb
+++ b/lib/clever_events_rails/clever_events/publishable.rb
@@ -7,6 +7,8 @@ module CleverEvents
   module Publishable
     extend ActiveSupport::Concern
 
+    attr_accessor :skip_publish
+
     included do
       class_attribute :_publishable_attrs, default: []
       class_attribute :_publishable_actions, default: %i[created updated destroyed]
@@ -41,8 +43,13 @@ module CleverEvents
     def publish_event?
       return false if self.class._publishable_attrs.empty?
       return false unless self.class._publishable_actions.include?(event_type)
+      return false if skip_publish?
 
       self.class._publishable_attrs.intersection(changes).any?
+    end
+
+    def skip_publish?
+      !!@skip_publish
     end
 
     def changes

--- a/spec/clever_events/publishable_spec.rb
+++ b/spec/clever_events/publishable_spec.rb
@@ -100,4 +100,32 @@ RSpec.describe CleverEvents::Publishable do
       end
     end
   end
+
+  describe "skipping publish" do
+    let(:test_object) { create(:test_object) }
+
+    describe "when skip_publish is true" do
+      it "does not call publish_event!" do
+        test_object.update(first_name: "New Name", skip_publish: true)
+
+        expect(CleverEvents::Publisher).not_to have_received(:publish_event!)
+      end
+    end
+
+    describe "when skip_publish is false" do
+      it "calls publish_event!" do
+        test_object.update(first_name: "New Name", skip_publish: false)
+
+        expect(CleverEvents::Publisher).to have_received(:publish_event!)
+      end
+    end
+
+    describe "when skip_publish is not set" do
+      it "calls publish_event!" do
+        test_object.update(first_name: "New Name")
+
+        expect(CleverEvents::Publisher).to have_received(:publish_event!)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Allow skipping of event publishing via an ivar on the publishable object