### PR TITLE
FIX - don't send message group id unless its a fifo topic

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    clever_events_rails (0.6.0)
+    clever_events_rails (0.6.1)
       activesupport
       aws-sdk-sns
       aws-sdk-sqs

--- a/gemfiles/rails_7_1.gemfile.lock
+++ b/gemfiles/rails_7_1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    clever_events_rails (0.6.0)
+    clever_events_rails (0.6.1)
       activesupport
       aws-sdk-sns
       aws-sdk-sqs

--- a/gemfiles/rails_8_0.gemfile.lock
+++ b/gemfiles/rails_8_0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    clever_events_rails (0.6.0)
+    clever_events_rails (0.6.1)
       activesupport
       aws-sdk-sns
       aws-sdk-sqs

--- a/lib/clever_events_rails/clever_events/adapters/sns_adapter.rb
+++ b/lib/clever_events_rails/clever_events/adapters/sns_adapter.rb
@@ -47,10 +47,9 @@ module CleverEvents
           topic_arn: topic_arn,
           message: message.build_message,
           subject: event_name,
-          message_group_id: message_group_id(entity),
           message_attributes: message.message_attributes
         }.tap do |options|
-          options[:message_deduplication_id] = message_deduplication_id if CleverEvents.configuration.fifo_topic?
+          options.merge!(fifo_options) if CleverEvents.configuration.fifo_topic?
         end
       end
 
@@ -72,6 +71,13 @@ module CleverEvents
 
       def message_group_id(entity)
         "#{entity.class.name.underscore.downcase}.#{entity.id}"
+      end
+
+      def fifo_options
+        {
+          message_deduplication_id: message_deduplication_id,
+          message_group_id: message_group_id(entity)
+        }
       end
     end
   end

--- a/lib/clever_events_rails/version.rb
+++ b/lib/clever_events_rails/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module CleverEventsRails
-  VERSION = "0.6.0"
+  VERSION = "0.6.1"
 end

--- a/spec/clever_events/adapters/sns_adapter_spec.rb
+++ b/spec/clever_events/adapters/sns_adapter_spec.rb
@@ -24,7 +24,6 @@ RSpec.describe CleverEvents::Adapters::SnsAdapter, type: :model do
         topic_arn: CleverEvents.configuration.sns_topic_arn,
         message: CleverEvents::Message.new("test_event", test_object).build_message,
         subject: "test_event",
-        message_group_id: "test_object.#{test_object.id}",
         message_attributes: CleverEvents::Message.new("test_event", test_object).message_attributes
       )
     end
@@ -48,7 +47,6 @@ RSpec.describe CleverEvents::Adapters::SnsAdapter, type: :model do
         topic_arn: custom_topic_arn,
         message: CleverEvents::Message.new("test_event", test_object).build_message,
         subject: "test_event",
-        message_group_id: "test_object.#{test_object.id}",
         message_attributes: CleverEvents::Message.new("test_event", test_object).message_attributes
       )
     end


### PR DESCRIPTION
Self explanatory title, but standard topics will error if events are sent that have fifo-specific attributes