### PR TITLE
ACE-378 Handle SQS message processing success and failure

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,6 +7,7 @@ require:
 
 AllCops:
   TargetRubyVersion: 3.1
+  NewCops: enable
   Exclude:
     - "gemfiles/**/*"
     - vendor/bundle/**/*
@@ -26,3 +27,6 @@ RSpec/ExampleLength:
 
 RSpec/NestedGroups:
   Max: 5
+
+Gemspec/DevelopmentDependencies:
+  Enabled: false

--- a/.simplecov
+++ b/.simplecov
@@ -9,5 +9,5 @@ SimpleCov.start do
 
   formatter SimpleCov::Formatter::CoberturaFormatter if ENV["CI"]
 
-  SimpleCov.command_name "appraisal-#{ENV["BUNDLE_GEMFILE"]}"
+  SimpleCov.command_name "appraisal-#{ENV.fetch("BUNDLE_GEMFILE", nil)}"
 end

--- a/README.md
+++ b/README.md
@@ -31,16 +31,61 @@ Configure the gem in an initializer:
 ```ruby
 # config/initializers/clever_events.rb
 CleverEvents.configure do |config|
+  # Enable or disable event publishing (default: false)
   config.publish_events = true
-  config.sns_topic_arn = "arn:aws:sns:region:account-id:topic-name"
-  config.sqs_queue_url = "https://sqs.region.amazonaws.com/account-id/queue-name"
+
+  # AWS Credentials
   config.aws_access_key_id = "your-access-key"
   config.aws_secret_access_key = "your-secret-key"
   config.aws_region = "us-east-1"
+
+  # SNS Configuration
+  config.sns_topic_arn = "arn:aws:sns:region:account-id:topic-name"
+  # Set to true if using FIFO topics (default: false)
+  config.fifo_topic = true
+
+  # SQS Configuration
+  config.sqs_queue_url = "https://sqs.region.amazonaws.com/account-id/queue-name"
+  # Optional Dead Letter Queue (DLQ) for failed messages
+  config.sqs_dlq_url = "https://sqs.region.amazonaws.com/account-id/dead-letter-queue-name"
+
+  # API Configuration
+  # Base URL for generating paths to API resources
   config.base_api_url = "http://localhost:3000/api"
-  config.fifo_topic = true # Set to true if using FIFO topics
+
+  # Batch Processing
+  # Number of messages to process in a batch (default: 1)
+  config.default_message_batch_size = 10
+
+  # Event Source
+  # Custom source identifier for published events (default: "clever_events_rails")
+  config.source = "my_application_name"
+
+  # Adapter Selection
+  # Choose adapter for publishing events: (default: :sns)
+  config.events_adapter = :sns
+  # Choose adapter for processing messages: (default: :sqs)
+  config.message_processor_adapter = :sqs
 end
 ```
+
+#### Configuration Options
+
+| Option                       | Description                                                    | Default                 |
+| ---------------------------- | -------------------------------------------------------------- | ----------------------- |
+| `publish_events`             | Enable or disable event publishing                             | `false`                 |
+| `aws_access_key_id`          | AWS access key ID                                              | `nil`                   |
+| `aws_secret_access_key`      | AWS secret access key                                          | `nil`                   |
+| `aws_region`                 | AWS region                                                     | `"us-east-1"`           |
+| `sns_topic_arn`              | ARN of the SNS topic to publish events to                      | `nil`                   |
+| `fifo_topic`                 | Set to true when using FIFO topics to enable deduplication IDs | `false`                 |
+| `sqs_queue_url`              | URL of the SQS queue to receive messages from                  | `nil`                   |
+| `sqs_dlq_url`                | URL of the Dead Letter Queue for failed messages               | `nil`                   |
+| `base_api_url`               | Base URL for generating API resource paths                     | `nil`                   |
+| `default_message_batch_size` | Number of messages to process in a batch                       | `1`                     |
+| `source`                     | Custom source identifier for published events                  | `"clever_events_rails"` |
+| `events_adapter`             | Adapter for publishing events (`:sns`)                         | `:sns`                  |
+| `message_processor_adapter`  | Adapter for processing messages (`:sns`)                       | `:sqs`                  |
 
 ### Publishing Events
 
@@ -62,18 +107,133 @@ Events will be published to SNS when:
 
 ### Processing Events
 
-Process events from SQS:
+#### Using the SQS Adapter
+
+The SQS adapter provides methods to interact with SQS:
 
 ```ruby
-CleverEvents::Subscriber.receive_messages
+# Receive messages from SQS
+messages = CleverEvents::Adapters::SqsAdapter.receive_messages(
+  queue_url: "custom-queue-url", # Optional, defaults to configured queue
+  max_number_of_messages: 10,     # Optional, defaults to configured batch size
+  wait_time_seconds: 10           # Optional, defaults to 0
+)
+
+# Delete a single message
+CleverEvents::Adapters::SqsAdapter.delete_message(
+  message: sqs_message,
+  queue_url: "custom-queue-url"   # Optional, defaults to configured queue
+)
+
+# Delete multiple messages in batches
+CleverEvents::Adapters::SqsAdapter.delete_messages(
+  messages: sqs_messages,
+  queue_url: "custom-queue-url"   # Optional, defaults to configured queue
+)
+
+# Process messages with a processor class
+CleverEvents::Adapters::SqsAdapter.process_messages(
+  messages: sqs_messages,
+  processor_class: MyProcessor,
+  queue_url: "custom-queue-url"   # Optional, defaults to configured queue
+)
+
+# Send a message to SQS (useful for DLQ scenarios)
+CleverEvents::Adapters::SqsAdapter.send_message(
+  queue_url: "queue-url",
+  message_body: "message body",
+  message_attributes: { ... }
+)
 ```
 
-This will:
+#### Creating Custom Message Processors
 
-1. Receive messages from SQS
-2. Process each message
-3. Delete processed messages from the queue
-4. Log processing results
+Create custom processors by extending the `CleverEvents::Processor` base class:
+
+```ruby
+class MyMessageProcessor < CleverEvents::Processor
+  def process_message
+    # Access the message via the message attribute
+    data = JSON.parse(message.body)
+
+    # Process your message here
+    MyModel.create!(data: data)
+
+    # Return true if processing succeeded
+    true
+  rescue StandardError => e
+    # You can handle errors here if needed
+    Rails.logger.error("Custom processing error: #{e.message}")
+
+    # Re-raise if you want the processor to handle retry logic
+    raise e
+  end
+end
+```
+
+Then use your processor:
+
+```ruby
+# Process a single message
+MyMessageProcessor.process(sqs_message, queue_url: "queue-url")
+
+# Process multiple messages
+messages.each do |msg|
+  MyMessageProcessor.process(msg, queue_url: "queue-url")
+end
+
+# Or use the adapter's process_messages method
+CleverEvents::Adapters::SqsAdapter.process_messages(
+  messages: messages,
+  processor_class: MyMessageProcessor
+)
+```
+
+#### Automatic Retry and Dead Letter Queue (DLQ) Handling
+
+The processor base class provides automatic handling for:
+
+1. Processing errors with SQS's native retry mechanism
+2. Moving messages to a Dead Letter Queue (DLQ) after max retries
+3. Error logging and tracking
+
+When a message fails processing:
+
+- If the retry count is below the maximum (controlled by SQS redrive policy),
+  the error is re-raised, which returns the message to SQS for retry
+- If the retry count exceeds the maximum and a DLQ is configured,
+  the message is sent to the DLQ with error details
+- If no DLQ is configured, a warning is logged
+
+The message sent to the DLQ includes additional attributes:
+
+```ruby
+{
+  "original_queue" => { data_type: "String", string_value: original_queue_url },
+  "failure_reason" => { data_type: "String", string_value: error_message },
+  "retry_count" => { data_type: "Number", string_value: retry_count },
+  "failed_at" => { data_type: "String", string_value: timestamp }
+}
+```
+
+#### Using Background Jobs
+
+For Rails applications, use ActiveJob to process messages in the background:
+
+```ruby
+class SqsMessageProcessorJob < ApplicationJob
+  queue_as :default
+
+  def perform
+    messages = CleverEvents::Adapters::SqsAdapter.receive_messages
+
+    CleverEvents::Adapters::SqsAdapter.process_messages(
+      messages: messages,
+      processor_class: MyMessageProcessor
+    )
+  end
+end
+```
 
 ### Message Format
 
@@ -106,10 +266,11 @@ Events are published in the following format:
 
 The gem provides error handling for:
 
-- Invalid topic configuration
+- Invalid topic or queue configuration
 - SNS publishing failures
 - SQS processing failures
 - Invalid message formats
+- DLQ handling errors
 
 Errors are logged and raised as `CleverEvents::Error` instances.
 

--- a/clever_events_rails.gemspec
+++ b/clever_events_rails.gemspec
@@ -11,6 +11,7 @@ Gem::Specification.new do |spec|
   spec.summary = "Smart event pub/sub for rails apps"
   spec.license = "MIT"
   spec.required_ruby_version = ">= 3.1.0"
+  spec.metadata["rubygems_mfa_required"] = "true"
 
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
@@ -47,8 +48,8 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "vcr"
   spec.add_development_dependency "webmock"
 
-  spec.add_runtime_dependency "activesupport"
-  spec.add_runtime_dependency "aws-sdk-sns"
-  spec.add_runtime_dependency "aws-sdk-sqs"
-  spec.add_runtime_dependency "railties", ">= 4.1"
+  spec.add_dependency "activesupport"
+  spec.add_dependency "aws-sdk-sns"
+  spec.add_dependency "aws-sdk-sqs"
+  spec.add_dependency "railties", ">= 4.1"
 end

--- a/lib/clever_events_rails/clever_events/adapters/sqs_adapter.rb
+++ b/lib/clever_events_rails/clever_events/adapters/sqs_adapter.rb
@@ -2,13 +2,14 @@
 
 require "aws-sdk-sqs"
 require "clever_events_rails/clever_events/adapters/aws_credentials"
+require "clever_events_rails/clever_events/processor"
 
 module CleverEvents
   module Adapters
-    module SqsAdapter
-      class << self
+    module SqsAdapter # rubocop:disable Metrics/ModuleLength
+      class << self # rubocop:disable Metrics/ClassLength
         def receive_messages(queue_url: default_queue_url, max_messages: 1, wait_time_seconds: 0)
-          raise "Invalid queue config" unless queue_url ||= default_queue_url
+          validate_queue_url(queue_url)
 
           response = sqs_client.receive_message(
             queue_url: queue_url,
@@ -22,14 +23,51 @@ module CleverEvents
           handle_receive_error(e)
         end
 
-        def delete_message(receipt_handle:, queue_url: default_queue_url)
-          raise "Invalid queue config" unless queue_url ||= default_queue_url
+        def process_messages(messages, processor_class: CleverEvents::Processor, queue_url: default_queue_url)
+          validate_queue_url(queue_url)
+          processed_messages = []
 
+          messages.each do |message|
+            processor_class.process(message, queue_url: queue_url)
+            processed_messages << message
+          rescue StandardError => e
+            Rails.logger.error("Failed to process message: #{e.message}")
+            next
+          end
+
+          delete_messages(processed_messages, queue_url: queue_url) if processed_messages.any?
+        end
+
+        def delete_messages(messages, queue_url: default_queue_url)
+          validate_queue_url(queue_url)
+          return if messages.empty?
+
+          messages.each_slice(10) do |batch|
+            entries = batch.map.with_index do |message, index|
+              { id: index.to_s, receipt_handle: message.receipt_handle }
+            end
+
+            delete_message_batch(entries: entries, queue_url: queue_url)
+          end
+        end
+
+        def delete_message(receipt_handle:, queue_url: default_queue_url)
+          validate_queue_url(queue_url)
           delete_message_from_sqs(receipt_handle, queue_url)
         rescue Aws::SQS::Errors::InvalidReceiptHandle => e
           handle_invalid_receipt_error(e)
         rescue StandardError => e
           handle_delete_error(e)
+        end
+
+        def send_message(queue_url:, message_body:, message_attributes:)
+          validate_queue_url(queue_url)
+          response = send_message_to_sqs(queue_url, message_body, message_attributes)
+          Rails.logger.info("Sent message to SQS: #{response.message_id}") if response
+          true
+        rescue StandardError => e
+          log_send_error(e)
+          raise e
         end
 
         private
@@ -48,6 +86,12 @@ module CleverEvents
 
         def default_queue_url
           CleverEvents.configuration.sqs_queue_url
+        end
+
+        def validate_queue_url(queue_url)
+          queue_url ||= default_queue_url
+
+          raise CleverEvents::Error, "Invalid queue config" unless queue_url
         end
 
         def handle_receive_error(error)
@@ -72,6 +116,41 @@ module CleverEvents
           )
           Rails.logger.info("Deleted message from SQS") if response
           true
+        end
+
+        def send_message_to_sqs(queue_url, message_body, message_attributes)
+          sqs_client.send_message(
+            queue_url: queue_url,
+            message_body: message_body,
+            message_attributes: message_attributes
+          )
+        end
+
+        def log_send_error(error)
+          Rails.logger.error("Failed to send message to SQS: #{error.message}")
+        end
+
+        def delete_message_batch(entries:, queue_url:)
+          response = sqs_client.delete_message_batch(
+            queue_url: queue_url,
+            entries: entries
+          )
+
+          log_batch_delete_failures(response.failed) if response&.failed && response.failed.any?
+
+          Rails.logger.info("Deleted #{entries.size} messages from SQS") if response
+          true
+        rescue StandardError => e
+          Rails.logger.error("Failed to batch delete messages from SQS: #{e.message}")
+          raise CleverEvents::Error, e.message
+        end
+
+        def log_batch_delete_failures(failed_entries)
+          failed_entries.each do |failed|
+            Rails.logger.error(
+              "Failed to delete message #{failed.id}: #{failed.code} - #{failed.message}"
+            )
+          end
         end
       end
     end

--- a/lib/clever_events_rails/clever_events/configuration.rb
+++ b/lib/clever_events_rails/clever_events/configuration.rb
@@ -22,7 +22,8 @@ module CleverEvents
                   :base_api_url,
                   :sqs_queue_url,
                   :default_message_batch_size,
-                  :source
+                  :source,
+                  :sqs_dlq_url
     attr_writer :events_adapter,
                 :message_processor_adapter
 
@@ -38,6 +39,7 @@ module CleverEvents
       @default_message_batch_size = DEFAULT_MESSAGE_BATCH_SIZE
       @fifo_topic = false
       @source = DEFAULT_SOURCE
+      @sqs_dlq_url = nil
     end
 
     def events_adapter

--- a/lib/clever_events_rails/clever_events/processor.rb
+++ b/lib/clever_events_rails/clever_events/processor.rb
@@ -2,8 +2,6 @@
 
 module CleverEvents
   class Processor
-    MAX_RETRIES = 3
-
     def self.process(message, queue_url: nil)
       new(message, queue_url: queue_url).process
     end
@@ -17,9 +15,8 @@ module CleverEvents
     def process
       process_message
     rescue StandardError => e
-      raise e if retry_count < MAX_RETRIES
-
-      handle_processing_error(e)
+      log_error(e)
+      raise e # Re-raise the error to let SQS handle retries and DLQ routing
     end
 
     private
@@ -30,56 +27,10 @@ module CleverEvents
       raise NotImplementedError, "#{self.class.name} must implement process_message method"
     end
 
-    def handle_processing_error(error)
-      log_error(error)
-
-      if dlq_configured?
-        attempt_move_to_dlq(error)
-      else
-        log_dlq_not_configured
-      end
-    end
-
     def log_error(error)
       Rails.logger.error("Failed to process message: #{error.message}")
       Rails.logger.error(error.backtrace.join("\n")) if error.backtrace
-    end
-
-    def attempt_move_to_dlq(error)
-      move_to_dlq(error)
-    rescue StandardError => e
-      Rails.logger.error("Failed to move message to DLQ: #{e.message}")
-      raise e
-    end
-
-    def log_dlq_not_configured
-      Rails.logger.warn("Message #{message.message_id} exceeded max retries but DLQ not configured")
-    end
-
-    def move_to_dlq(error)
-      CleverEvents::Adapters::SqsAdapter.send_message(
-        queue_url: CleverEvents.configuration.sqs_dlq_url,
-        message_body: message.body,
-        message_attributes: dlq_message_attributes(error)
-      )
-      log_dlq_success
-    end
-
-    def dlq_message_attributes(error)
-      message.message_attributes.merge(
-        "original_queue" => { data_type: "String", string_value: queue_url },
-        "failure_reason" => { data_type: "String", string_value: error.message },
-        "retry_count" => { data_type: "Number", string_value: retry_count.to_s },
-        "failed_at" => { data_type: "String", string_value: Time.current.iso8601 }
-      )
-    end
-
-    def log_dlq_success
-      Rails.logger.info("Moved failed message to DLQ: #{message.message_id}")
-    end
-
-    def dlq_configured?
-      CleverEvents.configuration.sqs_dlq_url.present?
+      Rails.logger.info("Message will be retried by SQS (current retry count: #{retry_count})")
     end
   end
 end

--- a/lib/clever_events_rails/clever_events/processor.rb
+++ b/lib/clever_events_rails/clever_events/processor.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+module CleverEvents
+  class Processor
+    MAX_RETRIES = 3
+
+    def self.process(message, queue_url: nil)
+      new(message, queue_url: queue_url).process
+    end
+
+    def initialize(message, queue_url: nil)
+      @message = message
+      @queue_url = queue_url
+      @retry_count = message.attributes["ApproximateReceiveCount"].to_i
+    end
+
+    def process
+      process_message
+    rescue StandardError => e
+      raise e if retry_count < MAX_RETRIES
+
+      handle_processing_error(e)
+    end
+
+    private
+
+    attr_reader :message, :retry_count, :queue_url
+
+    def process_message
+      raise NotImplementedError, "#{self.class.name} must implement process_message method"
+    end
+
+    def handle_processing_error(error)
+      log_error(error)
+
+      if dlq_configured?
+        attempt_move_to_dlq(error)
+      else
+        log_dlq_not_configured
+      end
+    end
+
+    def log_error(error)
+      Rails.logger.error("Failed to process message: #{error.message}")
+      Rails.logger.error(error.backtrace.join("\n")) if error.backtrace
+    end
+
+    def attempt_move_to_dlq(error)
+      move_to_dlq(error)
+    rescue StandardError => e
+      Rails.logger.error("Failed to move message to DLQ: #{e.message}")
+      raise e
+    end
+
+    def log_dlq_not_configured
+      Rails.logger.warn("Message #{message.message_id} exceeded max retries but DLQ not configured")
+    end
+
+    def move_to_dlq(error)
+      CleverEvents::Adapters::SqsAdapter.send_message(
+        queue_url: CleverEvents.configuration.sqs_dlq_url,
+        message_body: message.body,
+        message_attributes: dlq_message_attributes(error)
+      )
+      log_dlq_success
+    end
+
+    def dlq_message_attributes(error)
+      message.message_attributes.merge(
+        "original_queue" => { data_type: "String", string_value: queue_url },
+        "failure_reason" => { data_type: "String", string_value: error.message },
+        "retry_count" => { data_type: "Number", string_value: retry_count.to_s },
+        "failed_at" => { data_type: "String", string_value: Time.current.iso8601 }
+      )
+    end
+
+    def log_dlq_success
+      Rails.logger.info("Moved failed message to DLQ: #{message.message_id}")
+    end
+
+    def dlq_configured?
+      CleverEvents.configuration.sqs_dlq_url.present?
+    end
+  end
+end

--- a/spec/clever_events/adapters/sqs_adapter_spec.rb
+++ b/spec/clever_events/adapters/sqs_adapter_spec.rb
@@ -174,4 +174,369 @@ RSpec.describe CleverEvents::Adapters::SqsAdapter, type: :model do
       end
     end
   end
+
+  describe ".process_messages" do
+    # Define smaller helper methods to avoid method length violations
+    def test_message(id)
+      Aws::SQS::Types::Message.new(
+        message_id: "test-message-#{id}",
+        receipt_handle: "test-receipt-handle-#{id}",
+        body: "test message #{id}"
+      )
+    end
+
+    def test_messages
+      [test_message("1"), test_message("2")]
+    end
+
+    def large_test_batch
+      (1..25).map { |i| test_message(i.to_s) }
+    end
+
+    let(:processor_class) { class_double(CleverEvents::Processor) }
+
+    before do
+      allow(sqs_client).to receive(:delete_message_batch).and_return(
+        Aws::SQS::Types::DeleteMessageBatchResult.new(
+          successful: [
+            Aws::SQS::Types::DeleteMessageBatchResultEntry.new(id: "0"),
+            Aws::SQS::Types::DeleteMessageBatchResultEntry.new(id: "1")
+          ],
+          failed: []
+        )
+      )
+      allow(Rails.logger).to receive(:error)
+      allow(Rails.logger).to receive(:info)
+    end
+
+    it "processes each message with the processor class" do
+      allow(processor_class).to receive(:process)
+
+      described_class.process_messages(test_messages, processor_class: processor_class)
+
+      expect(processor_class).to have_received(:process).twice
+    end
+
+    it "deletes successfully processed messages using batch deletion" do
+      allow(processor_class).to receive(:process)
+
+      described_class.process_messages(test_messages, processor_class: processor_class)
+
+      expect(sqs_client).to have_received(:delete_message_batch).with(
+        queue_url: queue_url,
+        entries: [
+          { id: "0", receipt_handle: "test-receipt-handle-1" },
+          { id: "1", receipt_handle: "test-receipt-handle-2" }
+        ]
+      )
+    end
+
+    it "continues processing remaining messages when one fails" do
+      messages = test_messages
+      # First message fails, second succeeds
+      allow(processor_class).to receive(:process).with(messages[0], queue_url: queue_url)
+                                                 .and_raise(StandardError.new("Processing error"))
+      allow(processor_class).to receive(:process).with(messages[1], queue_url: queue_url)
+
+      described_class.process_messages(messages, processor_class: processor_class)
+
+      # Should only delete the second message
+      expect(sqs_client).to have_received(:delete_message_batch).with(
+        queue_url: queue_url,
+        entries: [{ id: "0", receipt_handle: "test-receipt-handle-2" }]
+      )
+    end
+
+    it "logs errors and continues processing other messages" do
+      messages = test_messages
+      error = StandardError.new("Processing error")
+      allow(processor_class).to receive(:process).with(messages[0], queue_url: queue_url)
+                                                 .and_raise(error)
+      allow(processor_class).to receive(:process).with(messages[1], queue_url: queue_url)
+
+      described_class.process_messages(messages, processor_class: processor_class)
+
+      expect(Rails.logger).to have_received(:error).with("Failed to process message: Processing error")
+    end
+
+    it "does not call delete_message_batch if no messages were successfully processed" do
+      # All messages fail
+      allow(processor_class).to receive(:process).and_raise(StandardError.new("Processing error"))
+
+      described_class.process_messages(test_messages, processor_class: processor_class)
+
+      expect(sqs_client).not_to have_received(:delete_message_batch)
+    end
+
+    context "with custom queue URL" do
+      let(:custom_queue_url) { "https://sqs.custom.amazonaws.com/123456789012/custom-queue" }
+
+      before do
+        allow(processor_class).to receive(:process)
+      end
+
+      it "passes the custom queue URL to the processor" do
+        described_class.process_messages(test_messages, processor_class: processor_class, queue_url: custom_queue_url)
+
+        expect(processor_class).to have_received(:process).twice
+      end
+
+      it "passes the custom queue URL to the batch deletion" do
+        described_class.process_messages(test_messages, processor_class: processor_class, queue_url: custom_queue_url)
+
+        expect(sqs_client).to have_received(:delete_message_batch).with(
+          queue_url: custom_queue_url,
+          entries: anything
+        )
+      end
+    end
+
+    it "processes messages in batches of 10" do
+      allow(processor_class).to receive(:process)
+
+      described_class.process_messages(large_test_batch, processor_class: processor_class)
+
+      # Should have called delete_message_batch 3 times (10, 10, 5)
+      expect(sqs_client).to have_received(:delete_message_batch).exactly(3).times
+    end
+
+    context "when queue_url is not set" do
+      before do
+        allow(CleverEvents.configuration).to receive(:sqs_queue_url).and_return(nil)
+      end
+
+      it "raises an error" do
+        expect do
+          described_class.process_messages(test_messages)
+        end.to raise_error(CleverEvents::Error, "Invalid queue config")
+      end
+    end
+  end
+
+  describe ".delete_messages" do
+    # Use smaller helper methods
+    def test_message(id)
+      Aws::SQS::Types::Message.new(
+        message_id: "test-message-#{id}",
+        receipt_handle: "test-receipt-handle-#{id}",
+        body: "test message #{id}"
+      )
+    end
+
+    def test_messages
+      [test_message("1"), test_message("2")]
+    end
+
+    def delete_batch_response
+      Aws::SQS::Types::DeleteMessageBatchResult.new(
+        successful: [
+          Aws::SQS::Types::DeleteMessageBatchResultEntry.new(id: "0"),
+          Aws::SQS::Types::DeleteMessageBatchResultEntry.new(id: "1")
+        ],
+        failed: []
+      )
+    end
+
+    before do
+      allow(sqs_client).to receive(:delete_message_batch).and_return(delete_batch_response)
+      allow(Rails.logger).to receive(:info)
+      allow(Rails.logger).to receive(:error)
+    end
+
+    it "sends delete_message_batch request with correct parameters" do
+      described_class.delete_messages(test_messages)
+
+      expect(sqs_client).to have_received(:delete_message_batch).with(
+        queue_url: queue_url,
+        entries: [
+          { id: "0", receipt_handle: "test-receipt-handle-1" },
+          { id: "1", receipt_handle: "test-receipt-handle-2" }
+        ]
+      )
+    end
+
+    it "logs success message when deletion succeeds" do
+      described_class.delete_messages(test_messages)
+
+      expect(Rails.logger).to have_received(:info).with("Deleted 2 messages from SQS")
+    end
+
+    it "allows custom queue URL to be specified" do
+      custom_queue_url = "https://sqs.custom.amazonaws.com/123456789012/custom-queue"
+
+      described_class.delete_messages(test_messages, queue_url: custom_queue_url)
+
+      expect(sqs_client).to have_received(:delete_message_batch).with(
+        queue_url: custom_queue_url,
+        entries: anything
+      )
+    end
+
+    it "processes messages in batches of 10" do
+      # Create 25 messages
+      large_batch = (1..25).map { |i| test_message(i.to_s) }
+
+      described_class.delete_messages(large_batch)
+
+      # Should have called delete_message_batch 3 times (10, 10, 5)
+      expect(sqs_client).to have_received(:delete_message_batch).exactly(3).times
+    end
+
+    it "handles empty message list" do
+      described_class.delete_messages([])
+      expect(sqs_client).not_to have_received(:delete_message_batch)
+    end
+
+    context "with deletion failures" do
+      before do
+        failure_response = Aws::SQS::Types::DeleteMessageBatchResult.new(
+          successful: [Aws::SQS::Types::DeleteMessageBatchResultEntry.new(id: "0")],
+          failed: [
+            Aws::SQS::Types::BatchResultErrorEntry.new(
+              id: "1",
+              code: "InternalError",
+              message: "Internal Error"
+            )
+          ]
+        )
+        allow(sqs_client).to receive(:delete_message_batch).and_return(failure_response)
+      end
+
+      it "logs failures" do
+        described_class.delete_messages(test_messages)
+
+        expect(Rails.logger).to have_received(:error)
+          .with("Failed to delete message 1: InternalError - Internal Error")
+      end
+    end
+
+    context "with batch deletion error" do
+      before do
+        allow(sqs_client).to receive(:delete_message_batch)
+          .and_raise(Aws::SQS::Errors::ServiceError.new(nil, "SQS Batch Delete Error"))
+      end
+
+      it "logs the error" do
+        begin
+          described_class.delete_messages(test_messages)
+        rescue StandardError
+          # Rescue to continue test
+        end
+
+        expect(Rails.logger).to have_received(:error)
+          .with("Failed to batch delete messages from SQS: SQS Batch Delete Error")
+      end
+
+      it "raises a CleverEvents error" do
+        expect do
+          described_class.delete_messages(test_messages)
+        end.to raise_error(CleverEvents::Error, "SQS Batch Delete Error")
+      end
+    end
+  end
+
+  describe ".send_message" do
+    # Define helper methods instead of instance variables or let
+    def message_body
+      "test message body"
+    end
+
+    def message_attributes
+      { "attribute" => { data_type: "String", string_value: "value" } }
+    end
+
+    def message_id
+      "test-message-id"
+    end
+
+    def send_message_response
+      instance_double(Aws::SQS::Types::SendMessageResult, message_id: message_id)
+    end
+
+    before do
+      allow(sqs_client).to receive(:send_message).and_return(send_message_response)
+      allow(Rails.logger).to receive(:info)
+      allow(Rails.logger).to receive(:error)
+    end
+
+    it "sends message to SQS with correct parameters" do
+      described_class.send_message(
+        queue_url: queue_url,
+        message_body: message_body,
+        message_attributes: message_attributes
+      )
+
+      expect(sqs_client).to have_received(:send_message).with(
+        queue_url: queue_url,
+        message_body: message_body,
+        message_attributes: message_attributes
+      )
+    end
+
+    it "logs the message ID after successful send" do
+      described_class.send_message(
+        queue_url: queue_url,
+        message_body: message_body,
+        message_attributes: message_attributes
+      )
+
+      expect(Rails.logger).to have_received(:info).with("Sent message to SQS: #{message_id}")
+    end
+
+    it "returns true when message is sent successfully" do
+      result = described_class.send_message(
+        queue_url: queue_url,
+        message_body: message_body,
+        message_attributes: message_attributes
+      )
+
+      expect(result).to be true
+    end
+
+    describe "when SQS returns an error" do
+      before do
+        allow(sqs_client).to receive(:send_message).and_raise(
+          Aws::SQS::Errors::ServiceError.new(nil, "SQS error")
+        )
+      end
+
+      it "logs the error" do
+        begin
+          described_class.send_message(
+            queue_url: queue_url,
+            message_body: message_body,
+            message_attributes: message_attributes
+          )
+        rescue StandardError
+          # Rescue to allow test to continue
+        end
+
+        expect(Rails.logger).to have_received(:error).with("Failed to send message to SQS: SQS error")
+      end
+
+      it "re-raises the error" do
+        expect do
+          described_class.send_message(
+            queue_url: queue_url,
+            message_body: message_body,
+            message_attributes: message_attributes
+          )
+        end.to raise_error(StandardError, "SQS error")
+      end
+    end
+
+    describe "when the queue_url is not set" do
+      it "raises an error" do
+        allow(CleverEvents.configuration).to receive(:sqs_queue_url).and_return(nil)
+
+        expect do
+          described_class.send_message(
+            queue_url: nil,
+            message_body: message_body,
+            message_attributes: message_attributes
+          )
+        end.to raise_error(CleverEvents::Error, "Invalid queue config")
+      end
+    end
+  end
 end

--- a/spec/clever_events/configuration_spec.rb
+++ b/spec/clever_events/configuration_spec.rb
@@ -3,6 +3,8 @@
 require "spec_helper"
 
 RSpec.describe CleverEvents::Configuration, type: :model do
+  let(:config) { described_class.new }
+
   describe "#initialize" do
     it "sets default values" do # rubocop:disable RSpec/MultipleExpectations
       config = described_class.new
@@ -35,6 +37,57 @@ RSpec.describe CleverEvents::Configuration, type: :model do
       expect(config.aws_access_key_id).to eq("new_access_key")
       expect(config.aws_secret_access_key).to eq("new_secret_key")
       expect(config.aws_region).to eq("us-west-2")
+    end
+  end
+
+  describe "#events_adapter" do
+    it "returns the sns adapter class when configured with :sns" do
+      config.events_adapter = :sns
+
+      expect(config.events_adapter).to eq(CleverEvents::Adapters::SnsAdapter)
+    end
+
+    it "returns the sqs adapter class when configured with :sqs" do
+      config.events_adapter = :sqs
+
+      expect(config.events_adapter).to eq(CleverEvents::Adapters::SqsAdapter)
+    end
+
+    it "returns the default adapter when an invalid adapter key is provided" do
+      config.events_adapter = :invalid_adapter
+
+      expect(config.events_adapter).to eq(CleverEvents::Adapters::SnsAdapter)
+    end
+  end
+
+  describe "#message_processor_adapter" do
+    it "returns the sns adapter class when configured with :sns" do
+      config.message_processor_adapter = :sns
+
+      expect(config.message_processor_adapter).to eq(CleverEvents::Adapters::SnsAdapter)
+    end
+
+    it "returns the sqs adapter class when configured with :sqs" do
+      config.message_processor_adapter = :sqs
+
+      expect(config.message_processor_adapter).to eq(CleverEvents::Adapters::SqsAdapter)
+    end
+
+    it "returns the default adapter when an invalid adapter key is provided" do
+      config.message_processor_adapter = :invalid_adapter
+
+      expect(config.message_processor_adapter).to eq(CleverEvents::Adapters::SqsAdapter)
+    end
+  end
+
+  describe "#fifo_topic?" do
+    it "returns false by default" do
+      expect(config.fifo_topic?).to be false
+    end
+
+    it "returns true when fifo_topic is set to true" do
+      config.instance_variable_set(:@fifo_topic, true)
+      expect(config.fifo_topic?).to be true
     end
   end
 end

--- a/spec/clever_events/processor_spec.rb
+++ b/spec/clever_events/processor_spec.rb
@@ -4,13 +4,18 @@ require "spec_helper"
 
 class DummyProcessor < CleverEvents::Processor
   def process_message
-    true
+    # Implementation for testing
   end
 end
 
+# Processor without process_message implementation
+class EmptyProcessor < CleverEvents::Processor
+  # Intentionally not implementing process_message
+end
+
 RSpec.describe CleverEvents::Processor do
+  let(:queue_url) { "https://sqs.region.amazonaws.com/account-id/queue-name" }
   let(:retry_count) { 1 }
-  let(:queue_url) { "test-queue-url" }
   let(:message) do
     instance_double(
       Aws::SQS::Types::Message,
@@ -20,128 +25,93 @@ RSpec.describe CleverEvents::Processor do
       attributes: { "ApproximateReceiveCount" => retry_count.to_s }
     )
   end
+
   let(:processor) { DummyProcessor.new(message, queue_url: queue_url) }
   let(:error) { StandardError.new("test error") }
 
   describe ".process" do
-    it "creates a new instance with queue_url" do
-      allow(described_class).to receive(:new).with(message, queue_url: queue_url).and_return(processor)
-
+    it "creates a processor instance with correct parameters" do
+      allow(DummyProcessor).to receive(:new).with(message, queue_url: queue_url).and_call_original
       DummyProcessor.process(message, queue_url: queue_url)
-      expect(described_class).to have_received(:new).with(message, queue_url: queue_url)
+      expect(DummyProcessor).to have_received(:new).with(message, queue_url: queue_url)
     end
 
-    it "calls process on the instance" do
-      allow(described_class).to receive(:new).with(message, queue_url: queue_url).and_return(processor)
-      allow(processor).to receive(:process)
+    it "calls process on the processor instance" do
+      instance = instance_spy(DummyProcessor)
+      allow(DummyProcessor).to receive(:new).and_return(instance)
 
       DummyProcessor.process(message, queue_url: queue_url)
-      expect(processor).to have_received(:process)
+
+      expect(instance).to have_received(:process)
+    end
+  end
+
+  describe "#initialize" do
+    it "sets the message" do
+      processor = DummyProcessor.new(message, queue_url: queue_url)
+      expect(processor.send(:message)).to eq(message)
+    end
+
+    it "sets the queue_url" do
+      processor = DummyProcessor.new(message, queue_url: queue_url)
+      expect(processor.send(:queue_url)).to eq(queue_url)
+    end
+
+    it "sets the retry count from message attributes" do
+      processor = DummyProcessor.new(message, queue_url: queue_url)
+
+      expect(processor.send(:retry_count)).to eq(1)
     end
   end
 
   describe "#process" do
-    it "raises NotImplementedError" do
-      expect { described_class.process(message) }.to raise_error(NotImplementedError)
-    end
-  end
+    it "calls process_message" do
+      allow(processor).to receive(:process_message)
 
-  describe "error handling" do
-    before do
-      allow(Rails.logger).to receive(:error)
-      allow(Rails.logger).to receive(:warn)
-      allow(Rails.logger).to receive(:info)
+      processor.process
+
+      expect(processor).to have_received(:process_message)
     end
 
-    context "when retry count is below max retries" do
-      before { allow(processor).to receive(:process_message).and_raise(error) }
+    it "raises NotImplementedError when process_message is not implemented" do
+      empty_processor = EmptyProcessor.new(message, queue_url: queue_url)
 
-      let(:retry_count) { 1 }
+      expect { empty_processor.process }.to raise_error(
+        NotImplementedError,
+        "EmptyProcessor must implement process_message method"
+      )
+    end
 
-      it "re-raises the error for SQS to handle retry" do
+    context "when an error occurs" do
+      before do
+        allow(Rails.logger).to receive(:error)
+        allow(Rails.logger).to receive(:info)
+        allow(processor).to receive(:process_message).and_raise(error)
+      end
+
+      it "logs the error message" do
+        # Suppress the actual error to focus on the logging behavior
+        allow(processor).to receive(:raise)
+
+        begin
+          processor.process
+        rescue StandardError
+          nil
+        end
+
+        expect(Rails.logger).to have_received(:error).with("Failed to process message: test error")
+      end
+
+      it "re-raises the error for SQS to handle" do
         expect { processor.process }.to raise_error(error)
       end
-    end
 
-    context "when retry count exceeds max retries" do
-      let(:retry_count) { 4 }
-
-      context "when DLQ is configured" do
-        before do
-          allow(CleverEvents.configuration).to receive(:sqs_dlq_url).and_return("dlq-url")
-          allow(CleverEvents::Adapters::SqsAdapter).to receive(:send_message).and_return(true)
+      it "logs that SQS will retry the message" do
+        suppress(StandardError) do
+          processor.process
         end
 
-        it "moves message to DLQ" do
-          allow(processor).to receive(:process).and_raise(error)
-
-          suppress(StandardError) do
-            processor.process
-            expect(CleverEvents::Adapters::SqsAdapter).to have_received(:send_message).with(
-              queue_url: "dlq-url",
-              message_body: message.body,
-              message_attributes: hash_including(
-                "original_queue" => { data_type: "String", string_value: queue_url },
-                "failure_reason" => { data_type: "String", string_value: error.message },
-                "retry_count" => { data_type: "Number", string_value: retry_count.to_s },
-                "failed_at" => { data_type: "String", string_value: Time.current.iso8601 }
-              )
-            )
-          end
-        end
-
-        it "logs success after moving to DLQ" do
-          allow(processor).to receive(:process).and_raise(error)
-
-          suppress(StandardError) do
-            processor.process
-            expect(Rails.logger).to have_received(:info).with("Moved failed message to DLQ: #{message.message_id}")
-          end
-        end
-
-        context "when DLQ send fails" do
-          before do
-            allow(CleverEvents.configuration).to receive(:sqs_dlq_url).and_return("dlq-url")
-            allow(processor).to receive(:process_message).and_raise(error)
-
-            # Setup DLQ error and SQS adapter in the before block
-            dlq_error = StandardError.new("DLQ error")
-            allow(CleverEvents::Adapters::SqsAdapter).to receive(:send_message).and_raise(dlq_error)
-          end
-
-          it "raises the DLQ error instead of the original error" do
-            # Use local variable for consistency with before block
-            dlq_error = StandardError.new("DLQ error")
-            allow(CleverEvents::Adapters::SqsAdapter).to receive(:send_message).and_raise(dlq_error)
-
-            expect { processor.process }.to raise_error(dlq_error)
-          end
-
-          it "logs the DLQ error" do
-            allow(Rails.logger).to receive(:error)
-            suppress(StandardError) do
-              processor.process
-              expect(Rails.logger).to have_received(:error).with(/Failed to move message to DLQ: DLQ error/)
-            end
-          end
-        end
-      end
-
-      context "when DLQ is not configured" do
-        before do
-          allow(CleverEvents.configuration).to receive(:sqs_dlq_url).and_return(nil)
-        end
-
-        it "logs a warning" do
-          allow(processor).to receive(:process).and_raise(error)
-
-          suppress(StandardError) do
-            processor.process
-            expect(Rails.logger).to have_received(:warn).with(
-              "Message #{message.message_id} exceeded max retries but DLQ not configured"
-            )
-          end
-        end
+        expect(Rails.logger).to have_received(:info).with("Message will be retried by SQS (current retry count: 1)")
       end
     end
   end
@@ -149,6 +119,7 @@ RSpec.describe CleverEvents::Processor do
   describe "#log_error" do
     before do
       allow(Rails.logger).to receive(:error)
+      allow(Rails.logger).to receive(:info)
     end
 
     it "logs the error message" do
@@ -164,199 +135,26 @@ RSpec.describe CleverEvents::Processor do
 
       expect(Rails.logger).to have_received(:error).with(error.backtrace.join("\n"))
     end
-  end
 
-  describe "#attempt_move_to_dlq" do
-    before do
-      allow(Rails.logger).to receive(:error)
+    it "logs the error message when backtrace is nil" do
+      allow(error).to receive(:backtrace).and_return(nil)
+      processor.send(:log_error, error)
+
+      expect(Rails.logger).to have_received(:error).with("Failed to process message: test error")
     end
 
-    it "delegates to move_to_dlq" do
-      allow(processor).to receive(:move_to_dlq)
+    it "does not attempt to log nil backtrace" do
+      allow(error).to receive(:backtrace).and_return(nil)
 
-      processor.send(:attempt_move_to_dlq, error)
+      processor.send(:log_error, error)
 
-      expect(processor).to have_received(:move_to_dlq).with(error)
+      expect(Rails.logger).to have_received(:error).exactly(1).times
     end
 
-    context "when move_to_dlq raises an error" do
-      before do
-        # Use a local variable for dlq_error in the before block
-        dlq_error = StandardError.new("DLQ error")
-        allow(processor).to receive(:move_to_dlq).and_raise(dlq_error)
-      end
+    it "logs a message about SQS retrying" do
+      processor.send(:log_error, error)
 
-      it "logs the error" do
-        # Create a new dlq_error for this test
-        dlq_error = StandardError.new("DLQ error")
-        allow(processor).to receive(:move_to_dlq).and_raise(dlq_error)
-
-        suppress(StandardError) do
-          processor.send(:attempt_move_to_dlq, error)
-          expect(Rails.logger).to have_received(:error).with("Failed to move message to DLQ: DLQ error")
-        end
-      end
-
-      it "re-raises the error" do
-        # Create a new dlq_error for this test
-        dlq_error = StandardError.new("DLQ error")
-        allow(processor).to receive(:move_to_dlq).and_raise(dlq_error)
-
-        expect { processor.send(:attempt_move_to_dlq, error) }.to raise_error(dlq_error)
-      end
-    end
-  end
-
-  describe "#log_dlq_not_configured" do
-    before do
-      allow(Rails.logger).to receive(:warn)
-    end
-
-    it "logs a warning about DLQ not being configured" do
-      processor.send(:log_dlq_not_configured)
-
-      expect(Rails.logger).to have_received(:warn)
-        .with("Message test-message-id exceeded max retries but DLQ not configured")
-    end
-  end
-
-  describe "#dlq_message_attributes" do
-    before do
-      allow(Time).to receive(:current).and_return(Time.new(2023, 1, 1, 12, 0, 0, 0))
-    end
-
-    let(:retry_count) { 3 }
-    let(:queue_url) { "original-queue-url" }
-    let(:message) do
-      instance_double(
-        Aws::SQS::Types::Message,
-        body: "test body",
-        message_id: "test-message-id",
-        message_attributes: { "existing" => "attribute" },
-        attributes: { "ApproximateReceiveCount" => retry_count.to_s }
-      )
-    end
-    let(:processor) { DummyProcessor.new(message, queue_url: queue_url) }
-    let(:error) { StandardError.new("test error") }
-
-    it "includes error information" do
-      result = processor.send(:dlq_message_attributes, error)
-
-      expect(result).to include(
-        "original_queue" => { data_type: "String", string_value: queue_url },
-        "failure_reason" => { data_type: "String", string_value: "test error" }
-      )
-    end
-
-    it "includes retry count and timestamp" do
-      result = processor.send(:dlq_message_attributes, error)
-
-      expect(result).to include(
-        "retry_count" => { data_type: "Number", string_value: "3" },
-        "failed_at" => { data_type: "String", string_value: "2023-01-01T12:00:00+00:00" }
-      )
-    end
-  end
-
-  describe "#log_dlq_success" do
-    before do
-      allow(Rails.logger).to receive(:info)
-    end
-
-    it "logs success message with message ID" do
-      processor.send(:log_dlq_success)
-
-      expect(Rails.logger).to have_received(:info)
-        .with("Moved failed message to DLQ: test-message-id")
-    end
-  end
-
-  describe "#handle_processing_error" do
-    before do
-      allow(Rails.logger).to receive(:error)
-      allow(Rails.logger).to receive(:warn)
-      allow(Rails.logger).to receive(:info)
-    end
-
-    let(:retry_count) { 4 }
-    let(:message) do
-      instance_double(
-        Aws::SQS::Types::Message,
-        body: "test body",
-        message_id: "test-message-id",
-        message_attributes: {},
-        attributes: { "ApproximateReceiveCount" => retry_count.to_s }
-      )
-    end
-    let(:processor) { DummyProcessor.new(message, queue_url: queue_url) }
-    let(:error) { StandardError.new("test error") }
-
-    context "when DLQ is configured" do
-      before do
-        allow(CleverEvents.configuration).to receive(:sqs_dlq_url).and_return("dlq-url")
-        allow(processor).to receive(:attempt_move_to_dlq)
-      end
-
-      it "attempts to move message to DLQ" do
-        processor.send(:handle_processing_error, error)
-
-        expect(processor).to have_received(:attempt_move_to_dlq).with(error)
-      end
-    end
-
-    context "when DLQ is not configured" do
-      before do
-        allow(CleverEvents.configuration).to receive(:sqs_dlq_url).and_return(nil)
-        allow(processor).to receive(:log_dlq_not_configured)
-      end
-
-      it "logs that DLQ is not configured" do
-        processor.send(:handle_processing_error, error)
-
-        expect(processor).to have_received(:log_dlq_not_configured)
-      end
-
-      it "does not attempt to move message to DLQ" do
-        allow(processor).to receive(:attempt_move_to_dlq)
-
-        processor.send(:handle_processing_error, error)
-
-        expect(processor).not_to have_received(:attempt_move_to_dlq)
-      end
-    end
-  end
-
-  describe "#move_to_dlq" do
-    before do
-      allow(CleverEvents.configuration).to receive(:sqs_dlq_url).and_return("dlq-url")
-      allow(CleverEvents::Adapters::SqsAdapter).to receive(:send_message).and_return(true)
-      allow(processor).to receive(:log_dlq_success)
-    end
-
-    let(:retry_count) { 3 }
-    let(:queue_url) { "original-queue-url" }
-    let(:message) do
-      instance_double(
-        Aws::SQS::Types::Message,
-        body: "test body",
-        message_id: "test-message-id",
-        message_attributes: {},
-        attributes: { "ApproximateReceiveCount" => retry_count.to_s }
-      )
-    end
-    let(:processor) { DummyProcessor.new(message, queue_url: queue_url) }
-    let(:error) { StandardError.new("test error") }
-
-    it "sends the message to the DLQ" do
-      processor.send(:move_to_dlq, error)
-
-      expect(CleverEvents::Adapters::SqsAdapter).to have_received(:send_message)
-    end
-
-    it "logs success after moving to DLQ" do
-      processor.send(:move_to_dlq, error)
-
-      expect(processor).to have_received(:log_dlq_success)
+      expect(Rails.logger).to have_received(:info).with("Message will be retried by SQS (current retry count: 1)")
     end
   end
 end

--- a/spec/clever_events/processor_spec.rb
+++ b/spec/clever_events/processor_spec.rb
@@ -1,0 +1,362 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+class DummyProcessor < CleverEvents::Processor
+  def process_message
+    true
+  end
+end
+
+RSpec.describe CleverEvents::Processor do
+  let(:retry_count) { 1 }
+  let(:queue_url) { "test-queue-url" }
+  let(:message) do
+    instance_double(
+      Aws::SQS::Types::Message,
+      body: "test body",
+      message_id: "test-message-id",
+      message_attributes: {},
+      attributes: { "ApproximateReceiveCount" => retry_count.to_s }
+    )
+  end
+  let(:processor) { DummyProcessor.new(message, queue_url: queue_url) }
+  let(:error) { StandardError.new("test error") }
+
+  describe ".process" do
+    it "creates a new instance with queue_url" do
+      allow(described_class).to receive(:new).with(message, queue_url: queue_url).and_return(processor)
+
+      DummyProcessor.process(message, queue_url: queue_url)
+      expect(described_class).to have_received(:new).with(message, queue_url: queue_url)
+    end
+
+    it "calls process on the instance" do
+      allow(described_class).to receive(:new).with(message, queue_url: queue_url).and_return(processor)
+      allow(processor).to receive(:process)
+
+      DummyProcessor.process(message, queue_url: queue_url)
+      expect(processor).to have_received(:process)
+    end
+  end
+
+  describe "#process" do
+    it "raises NotImplementedError" do
+      expect { described_class.process(message) }.to raise_error(NotImplementedError)
+    end
+  end
+
+  describe "error handling" do
+    before do
+      allow(Rails.logger).to receive(:error)
+      allow(Rails.logger).to receive(:warn)
+      allow(Rails.logger).to receive(:info)
+    end
+
+    context "when retry count is below max retries" do
+      before { allow(processor).to receive(:process_message).and_raise(error) }
+
+      let(:retry_count) { 1 }
+
+      it "re-raises the error for SQS to handle retry" do
+        expect { processor.process }.to raise_error(error)
+      end
+    end
+
+    context "when retry count exceeds max retries" do
+      let(:retry_count) { 4 }
+
+      context "when DLQ is configured" do
+        before do
+          allow(CleverEvents.configuration).to receive(:sqs_dlq_url).and_return("dlq-url")
+          allow(CleverEvents::Adapters::SqsAdapter).to receive(:send_message).and_return(true)
+        end
+
+        it "moves message to DLQ" do
+          allow(processor).to receive(:process).and_raise(error)
+
+          suppress(StandardError) do
+            processor.process
+            expect(CleverEvents::Adapters::SqsAdapter).to have_received(:send_message).with(
+              queue_url: "dlq-url",
+              message_body: message.body,
+              message_attributes: hash_including(
+                "original_queue" => { data_type: "String", string_value: queue_url },
+                "failure_reason" => { data_type: "String", string_value: error.message },
+                "retry_count" => { data_type: "Number", string_value: retry_count.to_s },
+                "failed_at" => { data_type: "String", string_value: Time.current.iso8601 }
+              )
+            )
+          end
+        end
+
+        it "logs success after moving to DLQ" do
+          allow(processor).to receive(:process).and_raise(error)
+
+          suppress(StandardError) do
+            processor.process
+            expect(Rails.logger).to have_received(:info).with("Moved failed message to DLQ: #{message.message_id}")
+          end
+        end
+
+        context "when DLQ send fails" do
+          before do
+            allow(CleverEvents.configuration).to receive(:sqs_dlq_url).and_return("dlq-url")
+            allow(processor).to receive(:process_message).and_raise(error)
+
+            # Setup DLQ error and SQS adapter in the before block
+            dlq_error = StandardError.new("DLQ error")
+            allow(CleverEvents::Adapters::SqsAdapter).to receive(:send_message).and_raise(dlq_error)
+          end
+
+          it "raises the DLQ error instead of the original error" do
+            # Use local variable for consistency with before block
+            dlq_error = StandardError.new("DLQ error")
+            allow(CleverEvents::Adapters::SqsAdapter).to receive(:send_message).and_raise(dlq_error)
+
+            expect { processor.process }.to raise_error(dlq_error)
+          end
+
+          it "logs the DLQ error" do
+            allow(Rails.logger).to receive(:error)
+            suppress(StandardError) do
+              processor.process
+              expect(Rails.logger).to have_received(:error).with(/Failed to move message to DLQ: DLQ error/)
+            end
+          end
+        end
+      end
+
+      context "when DLQ is not configured" do
+        before do
+          allow(CleverEvents.configuration).to receive(:sqs_dlq_url).and_return(nil)
+        end
+
+        it "logs a warning" do
+          allow(processor).to receive(:process).and_raise(error)
+
+          suppress(StandardError) do
+            processor.process
+            expect(Rails.logger).to have_received(:warn).with(
+              "Message #{message.message_id} exceeded max retries but DLQ not configured"
+            )
+          end
+        end
+      end
+    end
+  end
+
+  describe "#log_error" do
+    before do
+      allow(Rails.logger).to receive(:error)
+    end
+
+    it "logs the error message" do
+      processor.send(:log_error, error)
+
+      expect(Rails.logger).to have_received(:error).with("Failed to process message: test error")
+    end
+
+    it "logs the error backtrace" do
+      allow(error).to receive(:backtrace).and_return(["backtrace line 1", "backtrace line 2"])
+
+      processor.send(:log_error, error)
+
+      expect(Rails.logger).to have_received(:error).with(error.backtrace.join("\n"))
+    end
+  end
+
+  describe "#attempt_move_to_dlq" do
+    before do
+      allow(Rails.logger).to receive(:error)
+    end
+
+    it "delegates to move_to_dlq" do
+      allow(processor).to receive(:move_to_dlq)
+
+      processor.send(:attempt_move_to_dlq, error)
+
+      expect(processor).to have_received(:move_to_dlq).with(error)
+    end
+
+    context "when move_to_dlq raises an error" do
+      before do
+        # Use a local variable for dlq_error in the before block
+        dlq_error = StandardError.new("DLQ error")
+        allow(processor).to receive(:move_to_dlq).and_raise(dlq_error)
+      end
+
+      it "logs the error" do
+        # Create a new dlq_error for this test
+        dlq_error = StandardError.new("DLQ error")
+        allow(processor).to receive(:move_to_dlq).and_raise(dlq_error)
+
+        suppress(StandardError) do
+          processor.send(:attempt_move_to_dlq, error)
+          expect(Rails.logger).to have_received(:error).with("Failed to move message to DLQ: DLQ error")
+        end
+      end
+
+      it "re-raises the error" do
+        # Create a new dlq_error for this test
+        dlq_error = StandardError.new("DLQ error")
+        allow(processor).to receive(:move_to_dlq).and_raise(dlq_error)
+
+        expect { processor.send(:attempt_move_to_dlq, error) }.to raise_error(dlq_error)
+      end
+    end
+  end
+
+  describe "#log_dlq_not_configured" do
+    before do
+      allow(Rails.logger).to receive(:warn)
+    end
+
+    it "logs a warning about DLQ not being configured" do
+      processor.send(:log_dlq_not_configured)
+
+      expect(Rails.logger).to have_received(:warn)
+        .with("Message test-message-id exceeded max retries but DLQ not configured")
+    end
+  end
+
+  describe "#dlq_message_attributes" do
+    before do
+      allow(Time).to receive(:current).and_return(Time.new(2023, 1, 1, 12, 0, 0, 0))
+    end
+
+    let(:retry_count) { 3 }
+    let(:queue_url) { "original-queue-url" }
+    let(:message) do
+      instance_double(
+        Aws::SQS::Types::Message,
+        body: "test body",
+        message_id: "test-message-id",
+        message_attributes: { "existing" => "attribute" },
+        attributes: { "ApproximateReceiveCount" => retry_count.to_s }
+      )
+    end
+    let(:processor) { DummyProcessor.new(message, queue_url: queue_url) }
+    let(:error) { StandardError.new("test error") }
+
+    it "includes error information" do
+      result = processor.send(:dlq_message_attributes, error)
+
+      expect(result).to include(
+        "original_queue" => { data_type: "String", string_value: queue_url },
+        "failure_reason" => { data_type: "String", string_value: "test error" }
+      )
+    end
+
+    it "includes retry count and timestamp" do
+      result = processor.send(:dlq_message_attributes, error)
+
+      expect(result).to include(
+        "retry_count" => { data_type: "Number", string_value: "3" },
+        "failed_at" => { data_type: "String", string_value: "2023-01-01T12:00:00+00:00" }
+      )
+    end
+  end
+
+  describe "#log_dlq_success" do
+    before do
+      allow(Rails.logger).to receive(:info)
+    end
+
+    it "logs success message with message ID" do
+      processor.send(:log_dlq_success)
+
+      expect(Rails.logger).to have_received(:info)
+        .with("Moved failed message to DLQ: test-message-id")
+    end
+  end
+
+  describe "#handle_processing_error" do
+    before do
+      allow(Rails.logger).to receive(:error)
+      allow(Rails.logger).to receive(:warn)
+      allow(Rails.logger).to receive(:info)
+    end
+
+    let(:retry_count) { 4 }
+    let(:message) do
+      instance_double(
+        Aws::SQS::Types::Message,
+        body: "test body",
+        message_id: "test-message-id",
+        message_attributes: {},
+        attributes: { "ApproximateReceiveCount" => retry_count.to_s }
+      )
+    end
+    let(:processor) { DummyProcessor.new(message, queue_url: queue_url) }
+    let(:error) { StandardError.new("test error") }
+
+    context "when DLQ is configured" do
+      before do
+        allow(CleverEvents.configuration).to receive(:sqs_dlq_url).and_return("dlq-url")
+        allow(processor).to receive(:attempt_move_to_dlq)
+      end
+
+      it "attempts to move message to DLQ" do
+        processor.send(:handle_processing_error, error)
+
+        expect(processor).to have_received(:attempt_move_to_dlq).with(error)
+      end
+    end
+
+    context "when DLQ is not configured" do
+      before do
+        allow(CleverEvents.configuration).to receive(:sqs_dlq_url).and_return(nil)
+        allow(processor).to receive(:log_dlq_not_configured)
+      end
+
+      it "logs that DLQ is not configured" do
+        processor.send(:handle_processing_error, error)
+
+        expect(processor).to have_received(:log_dlq_not_configured)
+      end
+
+      it "does not attempt to move message to DLQ" do
+        allow(processor).to receive(:attempt_move_to_dlq)
+
+        processor.send(:handle_processing_error, error)
+
+        expect(processor).not_to have_received(:attempt_move_to_dlq)
+      end
+    end
+  end
+
+  describe "#move_to_dlq" do
+    before do
+      allow(CleverEvents.configuration).to receive(:sqs_dlq_url).and_return("dlq-url")
+      allow(CleverEvents::Adapters::SqsAdapter).to receive(:send_message).and_return(true)
+      allow(processor).to receive(:log_dlq_success)
+    end
+
+    let(:retry_count) { 3 }
+    let(:queue_url) { "original-queue-url" }
+    let(:message) do
+      instance_double(
+        Aws::SQS::Types::Message,
+        body: "test body",
+        message_id: "test-message-id",
+        message_attributes: {},
+        attributes: { "ApproximateReceiveCount" => retry_count.to_s }
+      )
+    end
+    let(:processor) { DummyProcessor.new(message, queue_url: queue_url) }
+    let(:error) { StandardError.new("test error") }
+
+    it "sends the message to the DLQ" do
+      processor.send(:move_to_dlq, error)
+
+      expect(CleverEvents::Adapters::SqsAdapter).to have_received(:send_message)
+    end
+
+    it "logs success after moving to DLQ" do
+      processor.send(:move_to_dlq, error)
+
+      expect(processor).to have_received(:log_dlq_success)
+    end
+  end
+end

--- a/spec/dummy_app/services/message_processor.rb
+++ b/spec/dummy_app/services/message_processor.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module DummyApp
+  class MessageProcessor < CleverEvents::Processor
+    def self.process(message)
+      new(message).process
+    end
+
+    def process
+      sns_notification = JSON.parse(message.body)
+      message_body = JSON.parse(sns_notification["Message"])
+
+      # Simulate processing
+      case message_body["event_name"]
+      when "TestEvent"
+        # Successful processing
+        true
+      else
+        raise "Unknown event type"
+      end
+    rescue JSON::ParserError => e
+      Rails.logger.error("Failed to parse message body as JSON: #{e.message}")
+      raise e
+    end
+  end
+end

--- a/spec/integration/sqs_message_processing_spec.rb
+++ b/spec/integration/sqs_message_processing_spec.rb
@@ -3,7 +3,7 @@
 require "spec_helper"
 
 module CleverEventsRails
-  RSpec.describe "SQS Message Processing Integration Test", type: :request do
+  RSpec.describe "SQS Message Processing Integration Test" do
     let(:sqs_client) { Aws::SQS::Client.new(stub_responses: true) }
     let(:queue_url) { "https://sqs.test.amazonaws.com/123456789012/test-queue" }
     let(:receipt_handle) { "test-receipt-handle" }


### PR DESCRIPTION
When a message is pulled off of a queue, the events gem should handle what is done with that message _after_ processing it, whether it's successful or a failure.

Here is (pulled from the README) the new functionality included here:

### Processing Events

#### Using the SQS Adapter

The SQS adapter provides methods to interact with SQS:

```ruby
# Receive messages from SQS
messages = CleverEvents::Adapters::SqsAdapter.receive_messages(
  queue_url: "custom-queue-url", # Optional, defaults to configured queue
  max_number_of_messages: 10,     # Optional, defaults to configured batch size
  wait_time_seconds: 10           # Optional, defaults to 0
)

# Delete a single message
CleverEvents::Adapters::SqsAdapter.delete_message(
  receipt_handle: sqs_message.receipt_handle,
  queue_url: "custom-queue-url"   # Optional, defaults to configured queue
)

# Delete multiple messages in batches
CleverEvents::Adapters::SqsAdapter.delete_messages(
  messages: sqs_messages,
  queue_url: "custom-queue-url"   # Optional, defaults to configured queue
)

# Process messages with a processor class
CleverEvents::Adapters::SqsAdapter.process_messages(
  messages: sqs_messages,
  processor_class: MyProcessor,
  queue_url: "custom-queue-url"   # Optional, defaults to configured queue
)

# Send a message to SQS
CleverEvents::Adapters::SqsAdapter.send_message(
  queue_url: "queue-url",
  message_body: "message body",
  message_attributes: { ... }
)
```

#### Creating Custom Message Processors

Create custom processors by extending the `CleverEvents::Processor` base class:

```ruby
class MyMessageProcessor < CleverEvents::Processor
  def process_message
    # Access the message via the message attribute
    data = JSON.parse(message.body)

    # Process your message here
    MyModel.create!(data: data)

    # Return true if processing succeeded
    true
  rescue StandardError => e
    # You can handle errors here if needed
    Rails.logger.error("Custom processing error: #{e.message}")

    # Re-raise if you want the processor to handle retry logic
    raise e
  end
end
```

Then use your processor:

```ruby
# Process a single message
MyMessageProcessor.process(sqs_message, queue_url: "queue-url")

# Process multiple messages
messages.each do |msg|
  MyMessageProcessor.process(msg, queue_url: "queue-url")
end

# Or use the adapter's process_messages method
CleverEvents::Adapters::SqsAdapter.process_messages(
  messages: messages,
  processor_class: MyMessageProcessor
)
```

#### Automatic Retry and Dead Letter Queue (DLQ) Handling

The processor relies on AWS SQS's native retry and dead letter queue functionality:

1. Configure your SQS queue with a redrive policy in AWS that specifies:

   - A Dead Letter Queue target (create a separate SQS queue for this)
   - A maximum receive count threshold (how many failed processing attempts before a message moves to the DLQ)

2. When a message fails processing in your application:

   - The processor logs the error and re-raises it
   - SQS's built-in retry mechanism handles returning the message to the queue
   - After exceeding the maximum receive count, SQS automatically moves the message to the DLQ

3. No manual DLQ handling is required in your code; AWS takes care of:
   - Tracking retry attempts via the ApproximateReceiveCount
   - Moving messages to the DLQ when retries are exhausted
   - Preserving the original message content

To set up a DLQ in AWS:

1. Create a regular SQS queue to serve as your DLQ
2. When creating or editing your source queue, configure the "Dead-letter queue" settings:
   - Enable the DLQ
   - Select your DLQ queue
   - Set the "Maximum receives" value (e.g., 5)

This approach is more reliable than handling DLQ logic in the application code because:

- AWS SQS guarantees delivery to the DLQ even if your application crashes
- Message retry counting is handled by AWS infrastructure
- You can use the AWS Console or APIs to inspect and redrive failed messages

The `sqs_dlq_url` setting in the configuration is still used for tracking and reference purposes.

#### Using Background Jobs

For Rails applications, use ActiveJob to process messages in the background:

```ruby
class SqsMessageProcessorJob < ApplicationJob
  queue_as :default

  def perform
    messages = CleverEvents::Subscriber.receive_messages

    messages.each do |message|
      begin
        process_message(message)
        CleverEvents::Adapters::SqsAdapter.delete_message(
          receipt_handle: message.receipt_handle
        )
      rescue StandardError => e
        Rails.logger.error("Failed to process message: #{e.class} - #{e.message}")
      end
    end
  end

  private

  def process_message(message)
    data = JSON.parse(message.body)
    Rails.logger.info("Processing message: #{data}")
    # Your custom processing logic here
  end
end
```