### PR TITLE
CLEANUP - housekeeping

### DIFF
--- a/lib/clever_events_rails/clever_events/configuration.rb
+++ b/lib/clever_events_rails/clever_events/configuration.rb
@@ -22,8 +22,7 @@ module CleverEvents
                   :base_api_url,
                   :sqs_queue_url,
                   :default_message_batch_size,
-                  :source,
-                  :sqs_dlq_url
+                  :source
     attr_writer :events_adapter,
                 :message_processor_adapter
 
@@ -39,7 +38,6 @@ module CleverEvents
       @default_message_batch_size = DEFAULT_MESSAGE_BATCH_SIZE
       @fifo_topic = false
       @source = DEFAULT_SOURCE
-      @sqs_dlq_url = nil
     end
 
     def events_adapter

--- a/lib/clever_events_rails/clever_events/processor.rb
+++ b/lib/clever_events_rails/clever_events/processor.rb
@@ -16,12 +16,12 @@ module CleverEvents
       process_message
     rescue StandardError => e
       log_error(e)
-      raise e # Re-raise the error to let SQS handle retries and DLQ routing
+      raise e
     end
 
     private
 
-    attr_reader :message, :retry_count, :queue_url
+    attr_reader :message, :queue_url, :retry_count
 
     def process_message
       raise NotImplementedError, "#{self.class.name} must implement process_message method"

--- a/spec/clever_events/configuration_spec.rb
+++ b/spec/clever_events/configuration_spec.rb
@@ -2,80 +2,67 @@
 
 require "spec_helper"
 
-RSpec.describe CleverEvents::Configuration, type: :model do
+RSpec.describe CleverEvents::Configuration do
   let(:config) { described_class.new }
 
   describe "#initialize" do
     it "sets default values" do # rubocop:disable RSpec/MultipleExpectations
-      config = described_class.new
-
+      expect(config.sns_topic_arn).to be_nil
+      expect(config.sqs_queue_url).to be_nil
       expect(config.publish_events).to be false
       expect(config.events_adapter).to eq(CleverEvents::Adapters::SnsAdapter)
-      expect(config.aws_access_key_id).to be_nil
-      expect(config.aws_secret_access_key).to be_nil
-      expect(config.aws_region).to eq("us-east-1")
+      expect(config.message_processor_adapter).to eq(CleverEvents::Adapters::SqsAdapter)
+      expect(config.fifo_topic?).to be false
+      expect(config.default_message_batch_size).to eq(1)
     end
   end
 
   describe "#configure" do
     it "allows configuration of values" do # rubocop:disable RSpec/MultipleExpectations
-      # stub config object to not affect other tests
       allow(CleverEvents).to receive(:configuration).and_return(described_class.new)
 
       CleverEvents.configure do |config|
-        config.publish_events = false
-        config.events_adapter = :sns
-        config.aws_access_key_id = "new_access_key"
-        config.aws_secret_access_key = "new_secret_key"
+        config.publish_events = true
+        config.sns_topic_arn = "test-arn"
         config.aws_region = "us-west-2"
       end
 
-      config = CleverEvents.configuration
-
-      expect(config.publish_events).to be false
-      expect(config.events_adapter).to eq(CleverEvents::Adapters::SnsAdapter)
-      expect(config.aws_access_key_id).to eq("new_access_key")
-      expect(config.aws_secret_access_key).to eq("new_secret_key")
-      expect(config.aws_region).to eq("us-west-2")
+      expect(CleverEvents.configuration.publish_events).to be true
+      expect(CleverEvents.configuration.sns_topic_arn).to eq("test-arn")
+      expect(CleverEvents.configuration.aws_region).to eq("us-west-2")
     end
   end
 
   describe "#events_adapter" do
     it "returns the sns adapter class when configured with :sns" do
       config.events_adapter = :sns
-
       expect(config.events_adapter).to eq(CleverEvents::Adapters::SnsAdapter)
     end
 
     it "returns the sqs adapter class when configured with :sqs" do
       config.events_adapter = :sqs
-
       expect(config.events_adapter).to eq(CleverEvents::Adapters::SqsAdapter)
     end
 
     it "returns the default adapter when an invalid adapter key is provided" do
-      config.events_adapter = :invalid_adapter
-
+      config.events_adapter = :invalid
       expect(config.events_adapter).to eq(CleverEvents::Adapters::SnsAdapter)
     end
   end
 
   describe "#message_processor_adapter" do
-    it "returns the sns adapter class when configured with :sns" do
-      config.message_processor_adapter = :sns
-
-      expect(config.message_processor_adapter).to eq(CleverEvents::Adapters::SnsAdapter)
-    end
-
     it "returns the sqs adapter class when configured with :sqs" do
       config.message_processor_adapter = :sqs
-
       expect(config.message_processor_adapter).to eq(CleverEvents::Adapters::SqsAdapter)
     end
 
-    it "returns the default adapter when an invalid adapter key is provided" do
-      config.message_processor_adapter = :invalid_adapter
+    it "returns the sns adapter class when configured with :sns" do
+      config.message_processor_adapter = :sns
+      expect(config.message_processor_adapter).to eq(CleverEvents::Adapters::SnsAdapter)
+    end
 
+    it "returns the default adapter when an invalid adapter key is provided" do
+      config.message_processor_adapter = :invalid
       expect(config.message_processor_adapter).to eq(CleverEvents::Adapters::SqsAdapter)
     end
   end

--- a/spec/clever_events/processor_spec.rb
+++ b/spec/clever_events/processor_spec.rb
@@ -3,9 +3,7 @@
 require "spec_helper"
 
 class DummyProcessor < CleverEvents::Processor
-  def process_message
-    # Implementation for testing
-  end
+  def process_message; end
 end
 
 # Processor without process_message implementation
@@ -90,13 +88,10 @@ RSpec.describe CleverEvents::Processor do
       end
 
       it "logs the error message" do
-        # Suppress the actual error to focus on the logging behavior
         allow(processor).to receive(:raise)
 
-        begin
+        suppress(StandardError) do
           processor.process
-        rescue StandardError
-          nil
         end
 
         expect(Rails.logger).to have_received(:error).with("Failed to process message: test error")
@@ -138,6 +133,7 @@ RSpec.describe CleverEvents::Processor do
 
     it "logs the error message when backtrace is nil" do
       allow(error).to receive(:backtrace).and_return(nil)
+
       processor.send(:log_error, error)
 
       expect(Rails.logger).to have_received(:error).with("Failed to process message: test error")

--- a/spec/integration/sqs_message_processing_spec.rb
+++ b/spec/integration/sqs_message_processing_spec.rb
@@ -154,10 +154,8 @@ module CleverEventsRails # rubocop:disable Metrics/ModuleLength
           receive_message: Aws::SQS::Types::ReceiveMessageResult.new(messages: messages),
           delete_message: {}
         )
-        # Make the anonymous class behave like a named class for testing
         stub_const("TestProcessor", test_processor_class)
 
-        # Store the first message for test access
         @test_message = messages.first
       end
 
@@ -186,11 +184,8 @@ module CleverEventsRails # rubocop:disable Metrics/ModuleLength
         allow(processor).to receive(:process_message).and_raise(error)
         allow(TestProcessor).to receive(:new).and_return(processor)
 
-        # Suppress the actual error to focus on the logging behavior
-        begin
+        suppress(StandardError) do
           TestProcessor.process(@test_message, queue_url: queue_url)
-        rescue StandardError
-          # Expected error
         end
 
         expect(logger).to have_received(:error).with("Failed to process message: Custom processor error")

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -21,8 +21,6 @@ helpers = Dir[File.join(gem_root, "spec", "support", "**", "*.rb")]
 helpers -= Dir[File.join(gem_root, "spec", "support", "test_models", "**", "*.rb")]
 helpers.each { |f| require f }
 
-# Configure RSpec
-
 RSpec.configure do |config|
   config.example_status_persistence_file_path = ".rspec_status"
 


### PR DESCRIPTION
- use suppress blocks in tests which require errors to be raised
- remove inline code comments
- update readme to remove old DLQ config references